### PR TITLE
style: re-export leveldb_sys dep, used in our API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ pub use database::comparator;
 pub use database::key;
 pub use database::util;
 
+// re-export any dep crates that are exposed in our public API
+pub use leveldb_sys;
+
 use leveldb_sys::{leveldb_major_version, leveldb_minor_version};
 
 


### PR DESCRIPTION
leveldb_sys is publicly exposed in Options::compression, and possibly elsewhere.

With this change, an rs-leveldb user can access
leveldb::leveldb_sys::Compression or other leveldb_sys elements without requiring an explicit Cargo dep on leveldb_sys.


note:  I did not check if any other crates are exposed in the public API.   That would be a worthwhile exercise, but this PR is useful as-is.